### PR TITLE
Set a specific initrd path for c2, in case the kernel is the same.

### DIFF
--- a/root/etc/init.d/netboot-kernel-links
+++ b/root/etc/init.d/netboot-kernel-links
@@ -6,7 +6,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 # Kernel version to boot on c2
 VERSION="3.19.0-42-lowlatency"
 VMLINUZ_PATH=/boot/vmlinuz-${VERSION}
-INITRD_PATH=/boot/initrd.img-${VERSION}
+INITRD_PATH=/boot/initrd.img-${VERSION}.c2
 VMLINUZ_LINK=${TFTPBOOT}/robot64/vmlinuz
 INITRD_LINK=${TFTPBOOT}/robot64/initrd.img
 

--- a/root/unionfs/overlay/etc/exports
+++ b/root/unionfs/overlay/etc/exports
@@ -8,4 +8,3 @@
 # /srv/nfs4        gss/krb5i(rw,sync,fsid=0,crossmnt)
 # /srv/nfs4/homes  gss/krb5i(rw,sync)
 #
-/home	10.68.0.0/24(rw,insecure,async,no_subtree_check,no_root_squash,insecure_locks)

--- a/root/unionfs/overlay/etc/udev/rules.d/71-pr2-network-interface.rules
+++ b/root/unionfs/overlay/etc/udev/rules.d/71-pr2-network-interface.rules
@@ -23,5 +23,5 @@ SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="00:1e:68:??:??:?
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="00:1e:68:??:??:?[13579bdf]", ATTR{type}=="1", KERNEL=="eth*", NAME="lan1"
 
 # CLEARPATH LAN PORTS
-#SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="d0:50:99:??:??:[02468ace]?", ATTR{type}=="1", NAME="lan0"
-#SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="d0:50:99:??:??:[13579bdf]?", ATTR{type}=="1", NAME="lan1"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="d0:50:99:??:??:?[02458ace]", ATTR{type}=="1", NAME="lan0"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="d0:50:99:??:??:?[13679bdf]", ATTR{type}=="1", NAME="lan1"

--- a/root/usr/sbin/c2init
+++ b/root/usr/sbin/c2init
@@ -65,7 +65,7 @@ unionmount()
 
 	mount -n --bind /$dir /$UPATH/master/$dir
 	host="/${UPATH}/overlay/${dir}=RW"
-	common="/$UPATH/master/${dir}=RW"
+	common="/$UPATH/master/${dir}=RO"
 	$UBIN $FUSE_OPT $UNION_OPT ${host}:${common} /$UPATH/union/$dir
 	mount -n --bind /$UPATH/union/$dir /$dir
 }
@@ -76,7 +76,7 @@ unionmount_ro()
 
 	mount -n --bind /$dir /$UPATH/master/$dir
 	host="/${UPATH}/overlay/${dir}=RW"
-	common="/$UPATH/master/${dir}=RW"
+	common="/$UPATH/master/${dir}=RO"
 
 	$UBIN $FUSE_OPT $UNION_OPT ${host}:${common} /$UPATH/union/$dir
 	mount -n --bind /$UPATH/union/$dir /$dir

--- a/root/var/lib/tftpboot/pxelinux.cfg/0A440002
+++ b/root/var/lib/tftpboot/pxelinux.cfg/0A440002
@@ -3,7 +3,7 @@ DEFAULT robot64
 TIMEOUT 3
 LABEL robot64
         kernel robot64/vmlinuz
-        append boot=nfs root=/dev/nfs selinux=0 initrd=robot64/initrd.img rw rootdelay=10 vga=extended nfsroot=10.68.0.1:/ ip=10.68.0.2:10.68.0.1:10.68.0.1:255.255.255.0:c2:eth1 nomodeset init=/usr/sbin/c2init console=ttyS0,57600 console=tty1 biosdevname=0 net.ifnames=1
+        append boot=nfs root=/dev/nfs selinux=0 initrd=robot64/initrd.img rw rootdelay=10 vga=extended nfsroot=10.68.0.1:/ ip=10.68.0.2:10.68.0.1:10.68.0.1:255.255.255.0:c2:lan0 nomodeset init=/usr/sbin/c2init console=ttyS0,57600 console=tty1 biosdevname=0 net.ifnames=1
 label bmc106
         kernel memdisk
         append initrd=disk-bios3a03-bmc106-wg0.1.img

--- a/root/var/lib/tftpboot/pxelinux.cfg/0A440002
+++ b/root/var/lib/tftpboot/pxelinux.cfg/0A440002
@@ -3,7 +3,7 @@ DEFAULT robot64
 TIMEOUT 3
 LABEL robot64
         kernel robot64/vmlinuz
-        append boot=nfs root=/dev/nfs selinux=0 initrd=robot64/initrd.img rw rootdelay=10 acpi=off numa=noacpi vga=extended nfsroot=10.68.0.1:/ ip=10.68.0.2:10.68.0.1:10.68.0.1:255.255.255.0:c2:eth1 noefi nomodeset init=/usr/sbin/c2init console=ttyS0,57600 console=tty1 biosdevname=0 net.ifnames=1
+        append boot=nfs root=/dev/nfs selinux=0 initrd=robot64/initrd.img rw rootdelay=10 vga=extended nfsroot=10.68.0.1:/ ip=10.68.0.2:10.68.0.1:10.68.0.1:255.255.255.0:c2:eth1 nomodeset init=/usr/sbin/c2init console=ttyS0,57600 console=tty1 biosdevname=0 net.ifnames=1
 label bmc106
         kernel memdisk
         append initrd=disk-bios3a03-bmc106-wg0.1.img


### PR DESCRIPTION
Otherwise this script will overwrite the initrd used by c1,
causing havoc later.

Signed-off-by: Matthieu Herrb <matthieu.herrb@laas.fr>