### PR TITLE
Don't re-export /home on c2.

### DIFF
--- a/root/unionfs/overlay/etc/exports
+++ b/root/unionfs/overlay/etc/exports
@@ -8,4 +8,3 @@
 # /srv/nfs4        gss/krb5i(rw,sync,fsid=0,crossmnt)
 # /srv/nfs4/homes  gss/krb5i(rw,sync)
 #
-/home	10.68.0.0/24(rw,insecure,async,no_subtree_check,no_root_squash,insecure_locks)


### PR DESCRIPTION
/home on c2 is already NFS-mounted. Re-exporting it is only calling
for trouble.

Signed-off-by: Matthieu Herrb <matthieu.herrb@laas.fr>