### PR TITLE
fuse-unionfs: set the intermediate level RO

### DIFF
--- a/root/usr/sbin/c2init
+++ b/root/usr/sbin/c2init
@@ -65,7 +65,7 @@ unionmount()
 
 	mount -n --bind /$dir /$UPATH/master/$dir
 	host="/${UPATH}/overlay/${dir}=RW"
-	common="/$UPATH/master/${dir}=RW"
+	common="/$UPATH/master/${dir}=RO"
 	$UBIN $FUSE_OPT $UNION_OPT ${host}:${common} /$UPATH/union/$dir
 	mount -n --bind /$UPATH/union/$dir /$dir
 }
@@ -76,7 +76,7 @@ unionmount_ro()
 
 	mount -n --bind /$dir /$UPATH/master/$dir
 	host="/${UPATH}/overlay/${dir}=RW"
-	common="/$UPATH/master/${dir}=RW"
+	common="/$UPATH/master/${dir}=RO"
 
 	$UBIN $FUSE_OPT $UNION_OPT ${host}:${common} /$UPATH/union/$dir
 	mount -n --bind /$UPATH/union/$dir /$dir


### PR DESCRIPTION
This was the configuration in precise, and it lets c2 correctly
access /var/lib as read/write.

I must admit that I don't fully understand the behaviour, which looks
like a bug in fuse-unionfs to me, but with this bug fixed, many
things work way better on c2.

Signed-off-by: Matthieu Herrb <matthieu.herrb@laas.fr>