### PR TITLE
c2: work around system freeze on shutdown

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,7 @@ DEB_DIVERT_FILES_pr2-netboot += \
 	/etc/default/atftpd.pr2-netboot \
 	/etc/default/dnsmasq.pr2-netboot \
 	/etc/init.d/umountnfs.sh.pr2-netboot \
+	/etc/init.d/umountfs.pr2-netboot \
 	/etc/init.d/sendsigs.pr2-netboot \
 	/etc/init/portmap.conf.pr2-netboot \
 	/etc/dnsmasq.conf.pr2-netboot \

--- a/root/etc/init.d/umountfs.pr2-netboot
+++ b/root/etc/init.d/umountfs.pr2-netboot
@@ -1,0 +1,135 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          umountfs
+# Required-Start:
+# Required-Stop:     umountroot
+# Default-Start:
+# Default-Stop:      0 6
+# Short-Description: Turn off swap and unmount all local file systems.
+# Description:
+### END INIT INFO
+
+PATH=/sbin:/usr/sbin:/bin:/usr/bin
+. /lib/init/vars.sh
+
+. /lib/lsb/init-functions
+
+umask 022
+
+do_stop () {
+	PROTECTED_MOUNTS="$(sed -n ':a;/^[^ ]* \/ /!{H;n;ba};{H;s/.*//;x;s/\n//;p}' /proc/mounts)"
+	WEAK_MTPTS="" # be gentle, don't use force
+	REG_MTPTS=""
+	TMPFS_MTPTS=""
+	while read -r DEV MTPT FSTYPE REST
+	do
+		echo "$PROTECTED_MOUNTS" | grep -qs "^$DEV $MTPT " && continue
+		case "$MTPT" in
+		  /|/proc|/dev|/.dev|/dev/pts|/dev/shm|/dev/.static/dev|/proc/*|/sys|/sys/*|/run|/run/*)
+			continue
+			;;
+		esac
+		case "$FSTYPE" in
+		  proc|procfs|linprocfs|sysfs|usbfs|usbdevfs|devpts)
+			continue
+			;;
+		  tmpfs)
+			TMPFS_MTPTS="$MTPT $TMPFS_MTPTS"
+			;;
+		  *)
+			if echo "$PROTECTED_MOUNTS" | grep -qs "^$DEV "; then
+				WEAK_MTPTS="$MTPT $WEAK_MTPTS"
+			else
+				REG_MTPTS="$MTPT $REG_MTPTS"
+			fi
+			;;
+		esac
+	done < /proc/mounts
+
+	#
+	# Make sure tmpfs file systems are umounted before turning off
+	# swap, to avoid running out of memory if the tmpfs filesystems
+	# use a lot of space.
+	#
+	if [ "$TMPFS_MTPTS" ]
+	then
+		if [ "$VERBOSE" = no ]
+		then
+			log_action_begin_msg "Unmounting temporary filesystems"
+			fstab-decode umount $TMPFS_MTPTS
+			log_action_end_msg $?
+		else
+			log_daemon_msg "Will now unmount temporary filesystems"
+			fstab-decode umount -v $TMPFS_MTPTS
+			log_end_msg $?
+		fi
+	fi
+
+	#
+	# Deactivate swap
+	#
+	if [ "$VERBOSE" = no ]
+	then
+		log_action_begin_msg "Deactivating swap"
+		swapoff -a >/dev/null
+		log_action_end_msg $?
+	else
+		log_daemon_msg "Will now deactivate swap"
+		swapoff -a -v
+		log_end_msg $?
+	fi
+
+	#
+	# Unmount local filesystems
+	#
+	if [ "$WEAK_MTPTS" ]; then
+		# Do not use -f umount option for WEAK_MTPTS
+		if [ "$VERBOSE" = no ]
+		then
+			log_action_begin_msg "Unmounting weak filesystems"
+			fstab-decode umount -r -d $WEAK_MTPTS
+			log_action_end_msg $?
+		else
+			log_daemon_msg "Will now unmount weak filesystems"
+			fstab-decode umount -v -r -d $WEAK_MTPTS
+			log_end_msg $?
+		fi
+	fi
+	if [ "$REG_MTPTS" ]
+	then
+		if [ "$VERBOSE" = no ]
+		then
+			# We'll unmount the partitions one after another
+			# unmounting them at the same time (as in debian's default script)
+			# freezes the kernel on C2
+			for r in $REG_MTPS; do
+				log_action_begin_msg "Unmounting $r"
+				fstab-decode umount -f -r -d $r
+				log_action_end_msg $?
+			done
+		else
+			log_daemon_msg "Will now unmount local filesystems"
+			fstab-decode umount -f -v -r -d $REG_MTPTS
+			log_end_msg $?
+		fi
+	fi
+}
+
+case "$1" in
+  start)
+	# No-op
+	;;
+  restart|reload|force-reload)
+	echo "Error: argument '$1' not supported" >&2
+	exit 3
+	;;
+  stop)
+	do_stop
+	;;
+  *)
+	echo "Usage: $0 start|stop" >&2
+	exit 3
+	;;
+esac
+
+:


### PR DESCRIPTION
Thanks a lot to @mherrb for [finding a case where c2 actually turns off](https://github.com/pr2-debs/pr2-netboot/pull/16#issuecomment-225906790)!
I wouldn't have thought of something as extreme...
So I debugged this further and came up with this patch.

@mherrb could you test this on your PR2? I would very much like to see this resolved upstream
and brutally halting the machine without stopping processes and unmounting filesystems shouldn't be an option...
As strange as it seems, over here this fixes the error 10 out of 10 trials.

more details below:

As send out by Clearpath, the second server, c2, failed to shutdown
and froze during the shutdown procedure.

The problematic point turned out to be the unmounting of the local filesystems.
As specified in debian's umountfs script, all required mount points are unmounted
simultanously. However, on c2's configuration, that stacks nfs and unionfs mounts,
this triggers the freeze. This could be a kernel bug, but at the moment, there
is no way to test this with a current kernel and there's no sense in debugging a two year old kernel...

I changed it to unmount the mount points in a for-loop and now c2 turns off
/ reboots as expected. Nothing else changed and if this is not required anymore,
this diversion file can be removed again.